### PR TITLE
fix css for cover image and header, fix styling on files

### DIFF
--- a/src/components/Album.jsx
+++ b/src/components/Album.jsx
@@ -1,11 +1,11 @@
-import { PropTypes } from "prop-types";
+import { PropTypes } from 'prop-types';
 import { CoverImage } from './CoverImage';
 
 export const Album = ({ album }) => {
   // TODO: remove this later on
   console.log(album);
 
-  const image = album.images.find(image => image.height === 640)
+  const image = album.images.find(image => image.height === 640);
 
   return (
     <div className="album-container">

--- a/src/components/CoverImage.jsx
+++ b/src/components/CoverImage.jsx
@@ -1,13 +1,13 @@
 import { PropTypes } from 'prop-types';
 //import { HoverImage } from './HoverImage';
 
-export const CoverImage = (album) => {
-    return (
-        //HoverImage goes here
-            <img src={album.img} className="album-image" alt={album.name} />
+export const CoverImage = album => {
+  return (
+    //HoverImage goes here
+    <img src={album.img} className="album-image" alt={album.name} />
   );
 };
 
 CoverImage.propTypes = {
-    album: PropTypes.object.isRequired,
-  };
+  album: PropTypes.object.isRequired,
+};

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,15 +1,13 @@
-import { PropTypes } from "prop-types";
+import { PropTypes } from 'prop-types';
 
 export const Header = ({ text }) => {
   return (
- 		<div className="header-container">
- 			<h4 className="header-text">
-                { text }
-            </h4>
- 		</div>
- 	);
- };
+    <div className="header-container">
+      <h3 className="header-text">{text}</h3>
+    </div>
+  );
+};
 
- Header.propTypes = {
-	text: PropTypes.string.isRequired,
-  };
+Header.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,13 @@ body {
 .album-container {
   max-width: 600px;
   aspect-ratio: 1 / 1;
+  position: relative;
+  width: 100%;
+}
+
+.album-container img {
+  max-width: 600px;
+  width: 100%;
 }
 
 .overlay {
@@ -43,13 +50,14 @@ body {
 
 .icon {
   filter: brightness(0) invert(1);
-  padding: 15px; 
+  padding: 15px;
 }
 
 .play {
   width: 40px;
 }
-.dots, .heart {
+.dots,
+.heart {
   width: 25px;
 }
 
@@ -60,7 +68,8 @@ body {
   opacity: 1;
 }
 
-.dots:hover, .heart:hover {
+.dots:hover,
+.heart:hover {
   width: 35px;
   transition: 0.2s;
   padding: 10px;

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,13 @@ body {
 }
 
 .header-container {
-  margin-top: 15px;
+  margin: 30px 10px 5px;
+  border-bottom: 1px solid rgba(130, 130, 130, 0.374);
+}
+
+h3 {
+  padding: 0px;
+  margin-bottom: 8px;
 }
 
 .album-container {

--- a/src/stretched-goal.json
+++ b/src/stretched-goal.json
@@ -1,3 +1,4 @@
+{
   "message": "Editor's picks",
   "playlists": {
     "href": "https://api.spotify.com/v1/browse/featured-playlists?country=CH&timestamp=2023-02-22T14%3A42%3A20&offset=0&limit=20",


### PR DESCRIPTION
This PR updates the css for the `CoverImage` and `Header` components. The changes for the `CoverImage` makes the page more responsive, with the image autoresizing when we resize the page. 

Also updates the styling on some of the files since we had a lot of unnecessary spaces / tabs on some of them.

![CoverImage](https://github.com/themisterkai/project-music-releases-vite/assets/9663970/d3680959-2531-46de-b268-1643858d1b30)
