### PR TITLE
fix props in cover-image

### DIFF
--- a/src/components/Album.jsx
+++ b/src/components/Album.jsx
@@ -1,17 +1,14 @@
 import { PropTypes } from 'prop-types';
+
 import { AlbumName } from './AlbumName';
 import { CoverImage } from './CoverImage';
 
 export const Album = ({ album }) => {
-  // TODO: remove this later on
-  // console.log(album);
-
   const image = album.images.find(image => image.height === 640);
-
   return (
     <div className="album-container">
-      <CoverImage img={image.url} alt={album.name} />
-      {<AlbumName albumName={album.name} uri={album.uri} />}
+      <CoverImage withHover img={image.url} name={album.name} />
+      <AlbumName albumName={album.name} uri={album.uri} />
     </div>
   );
 };

--- a/src/components/CoverImage.jsx
+++ b/src/components/CoverImage.jsx
@@ -1,15 +1,17 @@
 import { PropTypes } from 'prop-types';
 import { HoverOverlay } from './HoverOverlay';
 
-export const CoverImage = album => {
+export const CoverImage = ({ img, name, withHover }) => {
   return (
     <div className="image-container">
-      <HoverOverlay />
-      <img src={album.img} className="album-image" alt={album.name} />
+      {withHover ? <HoverOverlay /> : <></>}
+      <img src={img} className="album-image" alt={name} />
     </div>
   );
 };
 
 CoverImage.propTypes = {
-  album: PropTypes.object.isRequired,
+  img: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  withHover: PropTypes.bool,
 };


### PR DESCRIPTION
There was a bug with how we were initially passing down props to the `CoverImage` component that I didn't catch in my original review. This PR should fix the way we do that.

Also adds an option `withHover` to the `CoverImage` component.  `withHover` allows us to optionally display the Hover Overlay. This is useful if we want to reuse the `CoverImage` component (for example for playlists), but we don't necessarily want to display it with the `HoverOverlay` component