### PR TITLE
[Stretch Goal] Render playlist on the sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,12 +4,17 @@ import { Album } from './components/Album';
 import { Header } from './components/Header';
 import { Sidebar } from './components/Sidebar';
 import data from './data.json';
+import { playlists } from './stretched-goal.json';
 
 export const App = () => {
   const [isNavOpen, setIsNavOpen] = useState(false);
   return (
     <div>
-      <Sidebar isNavOpen={isNavOpen} setIsNavOpen={setIsNavOpen} />
+      <Sidebar
+        isNavOpen={isNavOpen}
+        setIsNavOpen={setIsNavOpen}
+        playlists={playlists.items}
+      />
       <div className="main-body">
         <div
           className={`${isNavOpen ? 'main-container-open' : 'main-container'}`}

--- a/src/components/Album.jsx
+++ b/src/components/Album.jsx
@@ -1,17 +1,14 @@
 import { PropTypes } from 'prop-types';
+
 import { AlbumName } from './AlbumName';
 import { CoverImage } from './CoverImage';
 
 export const Album = ({ album }) => {
-  // TODO: remove this later on
-  // console.log(album);
-
   const image = album.images.find(image => image.height === 640);
-
   return (
     <div className="album-container">
-      <CoverImage img={image.url} alt={album.name} />
-      {<AlbumName albumName={album.name} uri={album.uri} />}
+      <CoverImage withHover img={image.url} name={album.name} />
+      <AlbumName albumName={album.name} uri={album.uri} />
     </div>
   );
 };

--- a/src/components/CoverImage.jsx
+++ b/src/components/CoverImage.jsx
@@ -1,15 +1,17 @@
 import { PropTypes } from 'prop-types';
 import { HoverOverlay } from './HoverOverlay';
 
-export const CoverImage = album => {
+export const CoverImage = ({ img, name, withHover }) => {
   return (
     <div className="image-container">
-      <HoverOverlay />
-      <img src={album.img} className="album-image" alt={album.name} />
+      {withHover ? <HoverOverlay /> : <></>}
+      <img src={img} className="album-image" alt={name} />
     </div>
   );
 };
 
 CoverImage.propTypes = {
-  album: PropTypes.object.isRequired,
+  img: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  withHover: PropTypes.bool,
 };

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,9 @@
 import { PropTypes } from 'prop-types';
 
-export const Sidebar = ({ isNavOpen, setIsNavOpen }) => {
+import { Header } from './Header';
+import { Playlist } from './Sidebar/Playlist';
+
+export const Sidebar = ({ isNavOpen, setIsNavOpen, playlists }) => {
   return (
     <>
       <button
@@ -12,7 +15,12 @@ export const Sidebar = ({ isNavOpen, setIsNavOpen }) => {
         <span className="material-symbols-outlined">menu</span>
       </button>
       <nav className={`nav ${isNavOpen ? 'nav-open' : 'nav-closed'}`}>
-        <div className="nav-content"></div>
+        <div className="nav-content">
+          <Header text={'Playlists'} />
+          {playlists.map(playlist => (
+            <Playlist key={playlist.id} playlist={playlist} />
+          ))}
+        </div>
       </nav>
     </>
   );
@@ -21,4 +29,5 @@ export const Sidebar = ({ isNavOpen, setIsNavOpen }) => {
 Sidebar.propTypes = {
   isNavOpen: PropTypes.bool.isRequired,
   setIsNavOpen: PropTypes.func.isRequired,
+  playlists: PropTypes.array.isRequired,
 };

--- a/src/components/Sidebar/Playlist.jsx
+++ b/src/components/Sidebar/Playlist.jsx
@@ -1,0 +1,24 @@
+import { PropTypes } from 'prop-types';
+
+import { CoverImage } from '../CoverImage';
+import { AlbumName } from '../AlbumName';
+import { TracksInfo } from '../TracksInfo';
+
+export const Playlist = ({ playlist }) => {
+  return (
+    <div className="playlist-container">
+      <CoverImage img={playlist.images[0].url} name={playlist.name} />
+      <div className="playlist-text">
+        <AlbumName
+          albumName={playlist.name}
+          uri={playlist.external_urls.spotify}
+        />
+        <TracksInfo trackCount={`${playlist.tracks.total}`} />
+      </div>
+    </div>
+  );
+};
+
+Playlist.propTypes = {
+  playlist: PropTypes.object.isRequired,
+};

--- a/src/components/TracksInfo.jsx
+++ b/src/components/TracksInfo.jsx
@@ -1,0 +1,9 @@
+import { PropTypes } from 'prop-types';
+
+export const TracksInfo = ({ trackCount }) => {
+  return <div className="tracks-info">{trackCount} tracks</div>;
+};
+
+TracksInfo.propTypes = {
+  trackCount: PropTypes.number.isRequired,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@ body {
 }
 
 .header-container {
-  margin: 30px 10px 30px 0px;
+  margin: 30px 10px 15px 0px;
   border-bottom: 1px solid rgba(130, 130, 130, 0.374);
 }
 
@@ -168,4 +168,31 @@ h3 {
 
 .nav-closed .nav-content {
   visibility: hidden;
+}
+
+.playlist-container {
+  max-width: 300px;
+  display: inline-block;
+  margin-bottom: 10px;
+}
+
+.playlist-container .image-container {
+  width: 100px;
+  display: inline-block;
+}
+
+.playlist-text {
+  width: 190px;
+  display: inline-block;
+  margin-left: 5px;
+}
+
+.tracks-info {
+  font-size: 14px;
+  color: #a0a0a0;
+  font-weight: bold;
+}
+
+.pl .tracks-info .album-name {
+  display: inline-block;
 }


### PR DESCRIPTION
This PR adds the `Playlist` and `TracksInfo` component which we use to render playlists and their info to the sidebar.

We are reusing two other components to render the playlist namely the `CoverImage` and the `AlbumName` components.